### PR TITLE
fixed get_number function call 

### DIFF
--- a/src/gamevariable.rs
+++ b/src/gamevariable.rs
@@ -71,7 +71,7 @@ impl GameVariableManager {
             set_number(game_variable, key.into(), value, None);
         }   
     }
-    pub fn get_number(key: &str, value: i32) -> i32 {
+    pub fn get_number(key: &str) -> i32 {
         let game_variable = GameUserData::get_variable();
         unsafe {get_number(game_variable, key.into(), None) }
 

--- a/src/gamevariable.rs
+++ b/src/gamevariable.rs
@@ -24,7 +24,7 @@ pub fn entry(this: &GameVariable, key: &Il2CppString, num: i32, method_info: Opt
 pub fn entry_no_rewind(this: &GameVariable, key: &Il2CppString, num: i32, method_info: OptionalMethod) -> bool;
 
 #[unity::from_offset("App", "GameVariable", "GetNumber")]
-pub fn get_number(this: &GameVariable, key: &Il2CppString, num: i32, method_info: OptionalMethod) -> i32;
+pub fn get_number(this: &GameVariable, key: &Il2CppString, method_info: OptionalMethod) -> i32;
 
 #[skyline::from_offset(0x251efb0)]
 pub fn set_number(this: &GameVariable, key: &Il2CppString, num: i32, method_info: OptionalMethod);
@@ -73,7 +73,7 @@ impl GameVariableManager {
     }
     pub fn get_number(key: &str, value: i32) -> i32 {
         let game_variable = GameUserData::get_variable();
-        unsafe {get_number(game_variable, key.into(), value, None); }
+        unsafe {get_number(game_variable, key.into(), None) }
 
     }
 }

--- a/src/menu/config.rs
+++ b/src/menu/config.rs
@@ -97,8 +97,8 @@ impl ConfigBasicMenuItem {
         unsafe { configbasicmenuitem_change_key_value_int(value, min, max, step, None) }
     }
 
-    pub fn change_key_value_f(value: f64, min: f64, max: f64, step: f64) -> f64 {
-        unsafe { configbasicmenuitem_change_key_value_float(value, min, max, step, true, None) }
+    pub fn change_key_value_f(value: f32, min: f32, max: f32, step: f32) -> f32 {
+        unsafe { configbasicmenuitem_change_key_value_float(value, min, max, step, None) }
     }
 }
 
@@ -127,8 +127,8 @@ pub fn configbasicmenuitem_ctor(this: &ConfigBasicMenuItem, method_info: Optiona
 #[skyline::from_offset(0x2537920)]
 fn configbasicmenuitem_change_key_value_int(value: i32, min: i32, max: i32, step: i32, method_info: OptionalMethod) -> i32;
 
-#[skyline::from_offset(0x2537150)]
-fn configbasicmenuitem_change_key_value_float(value: f64, min: f64, max: f64, step: f64, repeat: bool, method_info: OptionalMethod) -> f64;
+#[skyline::from_offset(0x2537970)]
+fn configbasicmenuitem_change_key_value_float(value: f32, min: f32, max: f32, step: f32, method_info: OptionalMethod) -> f32;
 
 #[unity::from_offset("", "ConfigBasicMenuItem", "UpdateText")]
 fn configbasicmenuitem_update_text(this: &ConfigBasicMenuItem, method_info: OptionalMethod);


### PR DESCRIPTION
get_number had an extra i32 parameter by mistake

added get_number and set_number functions to GameVariableManager 

